### PR TITLE
feat: expose generic `FetchType`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -65,3 +65,15 @@ export type FetchCreate = <
   url: Parameters<F>[0],
   options?: Parameters<F>[1] & SpreadGeneric<FEs>
 ) => FetchReturn
+
+/**
+ * Generic fetch type
+ *
+ * ```
+ * type MyFetch = FetchType<typeof query>
+ * ```
+ */
+export type FetchType<FEs extends readonly FetchEnhancer[]> = (
+  url: Parameters<Fetch>[0],
+  options?: Parameters<Fetch>[1] & SpreadGeneric<FEs>
+) => FetchReturn


### PR DESCRIPTION
发现一些场景下无法使用 createFetch 生成类型（例如 React context 中是从外部注入了对象），要简化调用方使用，导出一个公操作类型的 generic type。